### PR TITLE
docs: clarify project status as early prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,63 @@
 # 🤖 AI DevOps Orchestrator
 
-**LangChain + n8n 기반 자동 트러블슈팅 및 배포 파이프라인**
+**LangChain + n8n 기반 자동 트러블슈팅 및 배포 파이프라인 (concept / early prototype)**
 
+[![Status](https://img.shields.io/badge/status-early%20prototype-orange)](#-current-status)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue)](https://hub.docker.com)
-[![AI](https://img.shields.io/badge/AI-Powered-green)](https://github.com/langchain-ai/langchain)
 
-> **실증된 성과**: 디버깅 시간 1-2시간 → **5분** (2400% 효율 향상)
+> ⚠️ **Status: Early Prototype.** 본 저장소는 LangChain + n8n 기반 DevOps 오케스트레이션의
+> **컨셉 데모**입니다. 현재 구현은 FastAPI 엔드포인트 1개와 키워드 매칭 기반 응답이며,
+> ChromaDB 벡터 학습·멀티 에이전트·자동 PR 생성 등은 **모두 로드맵**입니다.
+> 아래 "📊 Current Status" 섹션을 먼저 참고하세요.
 
-## ✨ 핵심 기능
+## 📊 Current Status
 
-### 🔄 완전 자동화 파이프라인
+| 영역 | 상태 |
+|------|------|
+| FastAPI 헬스체크 + `/analyze` 엔드포인트 | ✅ 동작 (키워드 매칭 기반) |
+| docker-compose 정의 (langchain-api, n8n, ChromaDB, Redis) | ✅ 작성됨 |
+| n8n 워크플로우 JSON 1개 | ✅ 작성됨 |
+| LangChain 통합 (LLM 추론, 프롬프트 체인) | 📋 미구현 (의존성만 선언) |
+| ChromaDB 벡터 학습·검색 | 📋 미구현 (의존성만 선언) |
+| 멀티 에이전트 (Error/Security/Performance/...) | 📋 로드맵 |
+| GitHub Auto-Fix PR 생성 | 📋 로드맵 |
+| 자체 CI/CD (lint, type, test) | 📋 미구성 |
+| 테스트 (`tests/`) | 📋 비어있음 |
+
+> 현 구현의 `/analyze`는 에러 로그에 특정 키워드(`pure-rand` 등)가 포함되면
+> 미리 정의된 fix 제안을 반환합니다. LLM/벡터 검색은 아직 호출하지 않습니다.
+
+## 🎯 Planned Features (Roadmap)
+
+아래는 **목표 기능**이며 현재 구현되지 않았습니다.
+
+### 🔄 자동화 파이프라인 (목표)
 ```
 GitHub Push → n8n Trigger → LangChain Analysis → ChromaDB Learning → Auto-Fix
      ↓             ↓              ↓                ↓               ↓
-  실시간 감지   워크플로우 실행   AI 6개 에이전트    벡터 저장    즉시 해결
+  실시간 감지   워크플로우 실행   AI 에이전트       벡터 저장      Fix 제안
 ```
 
-### 🎯 차별화 포인트
+### 🎯 차별화 포인트 (목표)
 - **🧠 실시간 학습**: 매 배포마다 에러 패턴 축적 및 예측적 해결
-- **🌐 멀티 프레임워크**: Next.js, Django, React, Vue, Spring Boot 지원
-- **⚡ 제로 다운타임**: 자동 롤백 + 헬스체크 연동
+- **🌐 멀티 프레임워크**: Next.js, Django, React, Vue, Spring Boot
+- **⚡ 자동 롤백**: 헬스체크 실패 시 직전 SHA로 복원
 - **📊 벡터 기반 학습**: ChromaDB로 cross-project 패턴 공유
 
-### 🔥 실제 검증된 사례
-- **Prisma v7 의존성 체인 문제**: `pure-rand` → `pathe` → `proper-lockfile` 연쇄 해결
-- **Docker Alpine 호환성**: `npx` → 직접 경로 자동 전환
-- **GitHub Actions 비용**: hosted → self-hosted 자동 감지 및 전환
+### 📚 Reference Patterns (Hardcoded Examples)
 
-## 🚀 빠른 시작 (3분 설치)
+`/analyze` 엔드포인트가 인식하는 키워드와 응답으로 미리 정의된 패턴들입니다.
+실제 fix는 별도 사람·도구가 수동으로 적용한 사례에서 추출했으며, 이 저장소가
+직접 자동 적용한 결과는 아닙니다.
+
+- **Prisma v7 의존성 체인**: `pure-rand` → `pathe` → `proper-lockfile`
+- **Docker Alpine 호환성**: `npx` → `node node_modules/prisma/build/index.js` 직접 경로
+- **GitHub Actions 러너**: hosted → self-hosted 전환 가이드
+
+## 🚀 빠른 시작 (로컬 실행)
+
+> 현재 시작하면 docker-compose 스택은 기동되지만, `/analyze`는 키워드 매칭만 수행합니다.
 
 ### 1. 저장소 클론
 ```bash
@@ -39,21 +68,21 @@ cd ai-devops-orchestrator
 ### 2. 환경 설정
 ```bash
 cp .env.example .env
-# .env 파일에서 필요한 API 키 설정:
-# - OPENAI_API_KEY (또는 ANTHROPIC_API_KEY)
+# .env 파일에서 키 설정:
+# - OPENAI_API_KEY / ANTHROPIC_API_KEY (현 시점에는 사용되지 않음 — 통합 예정)
 # - GITHUB_TOKEN
-# - PROJECT_WEBHOOK_URL
+# - N8N_BASIC_AUTH_PASSWORD (반드시 기본값 'changeme'에서 변경)
 ```
 
-### 3. 원클릭 실행
+### 3. 실행
 ```bash
 docker-compose up -d
 ```
 
 ### 4. 대시보드 접속
-- **n8n 워크플로우**: http://localhost:5678
-- **LangChain API**: http://localhost:8000
-- **ChromaDB**: http://localhost:8001
+- **n8n**: http://localhost:5678
+- **API 헬스체크**: http://localhost:8000/health
+- **ChromaDB**: http://localhost:8001 (서비스만 기동, 학습 코드는 미구현)
 
 ## 🏗️ 아키텍처
 
@@ -78,62 +107,59 @@ graph TB
     K --> M[Notification]
 ```
 
-## 🤖 AI 에이전트 구성
+## 🤖 AI 에이전트 로드맵 (모두 미구현)
 
-### 1. Error Pattern Analyzer
+> 현재 구현된 에이전트는 없습니다. 아래는 설계 단계의 목표 구성입니다.
+
+### 1. Error Pattern Analyzer (📋 Planned)
 - **역할**: 빌드/배포 에러 실시간 분석
-- **기술**: LangChain + GPT-4/Claude
-- **특징**: 의존성 체인, 환경 차이, 설정 오류 패턴 학습
+- **기술 후보**: LangChain + GPT-4 / Claude
+- **목표**: 의존성 체인, 환경 차이, 설정 오류 패턴 학습
 
-### 2. Security Vulnerability Scanner  
+### 2. Security Vulnerability Scanner (📋 Planned)
 - **역할**: 보안 취약점 자동 탐지
-- **기술**: OWASP Top 10 + 커스텀 룰셋
-- **특징**: XSS, SQL Injection, 의존성 취약점 스캔
+- **기술 후보**: OWASP Top 10 + 커스텀 룰셋
 
-### 3. Performance Regression Detector
+### 3. Performance Regression Detector (📋 Planned)
 - **역할**: 성능 저하 사전 감지
-- **기술**: 메트릭 트렌드 분석
-- **특징**: 응답 시간, 메모리 사용량, DB 쿼리 최적화
+- **기술 후보**: 메트릭 트렌드 분석
 
-### 4. Infrastructure Monitor
-- **역할**: 인프라 상태 24/7 모니터링  
-- **기술**: Docker, Kubernetes, GCP/AWS 연동
-- **특징**: 리소스 사용량, 헬스체크, 자동 스케일링
+### 4. Infrastructure Monitor (📋 Planned)
+- **역할**: 인프라 상태 모니터링
+- **기술 후보**: Docker, Kubernetes, GCP/AWS
 
-### 5. Code Quality Enforcer
+### 5. Code Quality Enforcer (📋 Planned)
 - **역할**: 코드 품질 표준 유지
-- **기술**: ESLint, SonarQube, 커스텀 룰
-- **특징**: 복잡도 분석, 테스트 커버리지, 문서화 검증
+- **기술 후보**: ESLint, SonarQube
 
-### 6. Deployment Orchestrator
+### 6. Deployment Orchestrator (📋 Planned)
 - **역할**: 배포 파이프라인 자동 관리
-- **기술**: GitOps + Canary 배포
-- **특징**: 단계별 배포, 자동 롤백, 헬스체크 연동
+- **기술 후보**: GitOps + Canary
 
-## 🌟 지원 프레임워크
+## 🌟 지원 프레임워크 (목표)
 
-| 프레임워크 | 언어 | 지원 상태 | 특수 기능 |
-|-----------|------|-----------|----------|
-| **Next.js** | TypeScript/JavaScript | ✅ 완전 지원 | App Router, Prisma 호환 |
-| **Django** | Python | ✅ 완전 지원 | ORM 최적화, Celery 연동 |
-| **React** | TypeScript/JavaScript | ✅ 완전 지원 | Vite, Webpack 호환 |
-| **Vue.js** | TypeScript/JavaScript | ✅ 완전 지원 | Nuxt.js 포함 |
-| **Spring Boot** | Java/Kotlin | ✅ 완전 지원 | Gradle, Maven 지원 |
-| **FastAPI** | Python | 🔄 개발 중 | Pydantic, SQLAlchemy |
-| **Ruby on Rails** | Ruby | 📋 계획됨 | ActiveRecord, Sidekiq |
+> 현재 어느 프레임워크도 자동 fix를 적용하지 않습니다. 아래는 목표 범위입니다.
 
-## 📊 성과 지표
+| 프레임워크 | 언어 | 상태 |
+|-----------|------|------|
+| Next.js | TypeScript/JavaScript | 📋 Planned (참고 패턴 일부 하드코딩) |
+| Django | Python | 📋 Planned |
+| React | TypeScript/JavaScript | 📋 Planned |
+| Vue.js | TypeScript/JavaScript | 📋 Planned |
+| Spring Boot | Java/Kotlin | 📋 Planned |
+| FastAPI | Python | 📋 Planned |
+| Ruby on Rails | Ruby | 📋 Planned |
 
-### 실증된 개선 효과
-- **디버깅 시간**: 평균 90분 → **3.7분** (2343% 향상)
-- **배포 실패율**: 23% → **2.1%** (91% 감소)  
-- **MTTR**: 4.2시간 → **11분** (2190% 향상)
-- **개발 생산성**: +340% (반복 작업 자동화)
+## 📈 목표 지표 (Aspirational, 측정 전)
 
-### 비용 절감
-- **GitHub Actions 비용**: 월 $500 → $50 (90% 절감)
-- **인프라 모니터링 비용**: 월 $800 → $120 (85% 절감)
-- **On-call 비용**: 주 40시간 → 5시간 (87.5% 절감)
+> 아래 수치는 **벤치마크가 아닌 목표값**입니다. 실제 성과 측정은 통합 후 별도 보고합니다.
+
+- 디버깅 시간 단축
+- 배포 실패율 감소
+- MTTR 단축
+- CI/CD 비용 절감
+
+(상세 수치는 실제 통합·측정 이후 본 README에 추가합니다.)
 
 ## 🔧 커스터마이징
 
@@ -202,8 +228,7 @@ class CustomFrameworkAnalyzer(BaseAnalyzer):
 ## 💬 커뮤니티
 
 - **GitHub Discussions**: [토론 참여](https://github.com/rladmsgh34/ai-devops-orchestrator/discussions)
-- **Discord**: [커뮤니티 채팅](https://discord.gg/ai-devops)
-- **Twitter**: [@AIDevOpsOrg](https://twitter.com/AIDevOpsOrg)
+- Discord / Twitter: 운영 전 (커뮤니티 채널은 향후 개설 예정)
 
 ## 🙏 감사 인사
 


### PR DESCRIPTION
## Summary

본 저장소의 README가 현재 코드 구현과 일치하지 않는 부분(검증된 성과, 완전 지원 프레임워크, 6개 에이전트 등)을 정직하게 정리합니다.

## 배경

기존 README의 주장과 실제 코드의 격차:

| README 주장 | 실제 |
|---|---|
| "실증된 성과: 디버깅 1-2h → 5min (2400% 향상)" | 한 번도 운영 실행되지 않음 (run 0건) |
| "MTTR 4.2h → 11min", "월 \$500 → \$50" 등 정량 수치 | 측정 근거 없음 |
| "AI 6개 에이전트", "ChromaDB 벡터 학습" | `services/langchain-api/main.py` 1개 파일 121줄, LangChain·ChromaDB import 없음 |
| Next.js/Django/React/Vue/Spring "✅ 완전 지원" | 자동 fix 적용 사례 0건, 키워드 매칭 하드코딩 |
| Discord, Twitter 링크 | 운영되지 않는 채널 |

`tests/` 디렉토리 비어있음, 자체 CI 워크플로우 없음.

## 변경 사항

코드 변경 없음. README만 수정:

- 상단에 `early prototype` 배지 + 최상단 경고 박스
- **Current Status 매트릭스** 신규 섹션: 동작 ✅ / 미구현 📋 명시
- "🔥 실제 검증된 사례" → "📚 Reference Patterns (Hardcoded Examples)"로 재구성
- "🤖 AI 에이전트 6개" → 모두 "📋 Planned"로 표시
- 프레임워크 표 모든 ✅를 📋 Planned로 변경
- "📊 성과 지표" 섹션의 모든 정량 수치 제거, "Aspirational, 측정 전" 플레이스홀더로 대체
- 운영하지 않는 Discord/Twitter 링크 제거
- 빠른 시작 섹션에 "OPENAI_API_KEY 등은 현재 사용되지 않음" 주석, n8n 기본 패스워드 변경 권고

## 영향

- ✅ 코드 변경 0
- ✅ public 노출 시 잠재 신뢰 리스크 차단
- ✅ 향후 실제 구현(LangChain/ChromaDB 통합) 시 항목별 ✅ 전환 가능
- ⚠️ 기존 README의 "실증된 성과" 인용은 외부 어디서도 보이지 않으므로 회수 비용 없음

## 다음 단계 (별도 PR로 권장)

- 자체 CI 워크플로우(pytest, ruff, mypy) 추가
- LangChain 또는 ChromaDB 중 하나라도 실 통합 → Current Status 표 업데이트