### PR TITLE
docs: rewrite README in conductor-model + case-driven tone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,224 +1,74 @@
-# 🤖 AI DevOps Orchestrator
+# AI DevOps Orchestrator
 
-**LangChain + n8n 기반 자동 트러블슈팅 및 배포 파이프라인**
+> **포지션**: Claude Code(생성) → Antigravity(검증) → 사용자(승인) 세 액터를 잇는 **지휘자(conductor)**.
+> 코드를 직접 만들지 않고, 액터 사이의 컨텍스트·상태·게이트·학습을 매개합니다.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Docker](https://img.shields.io/badge/Docker-Ready-blue)](https://hub.docker.com)
-[![AI](https://img.shields.io/badge/AI-Powered-green)](https://github.com/langchain-ai/langchain)
+[![Status](https://img.shields.io/badge/status-case--driven%20bootstrap-orange)](#현재-상태)
 
-> ⚠️ **재정의 중 (2026-05 ~)**: 본 저장소는 "Claude Code(생성) → Antigravity(검증) → 사용자(승인)" 워크플로우의 **지휘자(conductor)** 모델로 재정의되었습니다. 아래 README의 "AI 6개 에이전트가 자동으로 수정 PR을 만든다"는 기존 모델은 폐기되었으며, 일부 컴포넌트(보안 스캐너, 코드 품질 룰 엔진, Auto-Fix PR)는 검증자(Antigravity) 역할과 충돌하여 제거되었습니다.
->
-> 새 설계는 다음을 참조하세요:
-> - [`CLAUDE.md`](./CLAUDE.md) — 프로젝트 운영 규칙
-> - [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — 지휘자 모델, 컴포넌트 매트릭스
-> - [`docs/PIPELINE_STATES.md`](./docs/PIPELINE_STATES.md) — 승인 상태머신
-> - [`cases/`](./cases) — 실제 케이스 로그 (개선의 유일한 근거)
+## 현재 상태
 
-## ✨ 핵심 기능
+이 저장소는 **케이스 주도 부트스트랩** 단계입니다. 척추(문서·스펙·게이트 정의)는 잡혔고, 컴포넌트 코드는 `cases/`에 실제 발생 근거가 쌓일 때마다 한 조각씩 추가됩니다.
 
-### 🔄 완전 자동화 파이프라인
-```
-GitHub Push → n8n Trigger → LangChain Analysis → ChromaDB Learning → Auto-Fix
-     ↓             ↓              ↓                ↓               ↓
-  실시간 감지   워크플로우 실행   AI 6개 에이전트    벡터 저장    즉시 해결
-```
+| 영역 | 상태 |
+|------|------|
+| 운영 규칙 (`CLAUDE.md`) | ✅ 확정 |
+| 지휘자 5-레이어 아키텍처 (`docs/ARCHITECTURE.md`) | ✅ 확정 |
+| 승인 상태머신 (`docs/PIPELINE_STATES.md`) | ✅ 스펙 확정 / ❌ 미구현 |
+| 케이스 로그 (`cases/`) | ✅ 워크플로우 시동 (case #000 resolved) |
+| FastAPI `/analyze` 키워드 매칭 데모 | ⚠️ 기존 코드 잔존 (지휘자 모델로 재작성 예정) |
+| Layer 1 컨텍스트 패커 | ❌ 미구현 (첫 케이스 대기) |
+| Layer 2 트리아지 라우터 | ❌ 미구현 |
+| Layer 3 컨텍스트 패킹 | ❌ 미구현 |
+| Layer 4 검증 게이트 | ❌ 미구현 |
+| Layer 5 승인+배포 게이트 | ❌ 미구현 |
+| ChromaDB 환류 루프 | ❌ 미구현 |
+| 테스트 (`tests/`) | ❌ 비어있음 |
+| 최소 CI (ruff + compose + yaml) | ✅ PR-only 트리거 |
 
-### 🎯 차별화 포인트
-- **🧠 실시간 학습**: 매 배포마다 에러 패턴 축적 및 예측적 해결
-- **🌐 멀티 프레임워크**: Next.js, Django, React, Vue, Spring Boot 지원
-- **⚡ 제로 다운타임**: 자동 롤백 + 헬스체크 연동
-- **📊 벡터 기반 학습**: ChromaDB로 cross-project 패턴 공유
+> 본 저장소는 **이전 버전(README 기준)에서 "AI 6개 에이전트가 자동 분석·수정 PR을 만든다"는 모델**을 폐기했습니다. 그 모델은 Claude Code(생성)·Antigravity(검증) 역할과 정면으로 충돌합니다. 자세한 폐기 결정은 [`cases/000-bootstrap.md`](./cases/000-bootstrap.md), 컴포넌트 매트릭스는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) 참조.
 
-### 🔥 실제 검증된 사례
-- **Prisma v7 의존성 체인 문제**: `pure-rand` → `pathe` → `proper-lockfile` 연쇄 해결
-- **Docker Alpine 호환성**: `npx` → 직접 경로 자동 전환
-- **GitHub Actions 비용**: hosted → self-hosted 자동 감지 및 전환
+## 작업 원칙
 
-## 🚀 빠른 시작 (3분 설치)
+1. **케이스 주도**: 새 컴포넌트는 `cases/NNN-*.md`에 실제 발생 근거가 있을 때만 코드화합니다. 가설 기반 기능 추가 금지.
+2. **액터 경계**: 새 작업을 받으면 "이건 어느 액터의 일인가, 오케스트레이터가 매개해야 하는가"를 먼저 묻습니다.
+3. **최소 척추 우선**: 문서·스펙·인터페이스 → 케이스 발생 → 최소 구현.
 
-### 1. 저장소 클론
+## 무엇을 만드는가 / 만들지 않는가
+
+| ✅ 만든다 | ❌ 만들지 않는다 |
+|---|---|
+| 컨텍스트 패커 (과거 사례 자동 주입) | AI가 자동으로 수정 PR 생성 (Claude Code와 충돌) |
+| 승인 상태머신 (`created → … → observed`) | 자체 코드 품질 룰 엔진 (Antigravity와 중복) |
+| 트리아지 라우터 (알림 분류) | 자체 보안 스캐너 (Antigravity와 중복) |
+| 런타임 → ChromaDB → 다음 작업 환류 루프 | 사용자 승인 없는 운영 배포 |
+| 배포 오케스트레이션 + 자동 롤백 | 투기적 기능 (아직 케이스 없는) |
+
+## 문서 맵
+
+- [`CLAUDE.md`](./CLAUDE.md) — 프로젝트 운영 규칙 (DO/DON'T, 액터 경계)
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — 지휘자 5-레이어 모델, 컴포넌트 제거/유지/신규 매트릭스
+- [`docs/PIPELINE_STATES.md`](./docs/PIPELINE_STATES.md) — 변경 → 운영 상태머신, 게이트 차단 시나리오 G1~G5
+- [`cases/`](./cases) — 실제 케이스 로그 (개선의 유일한 근거)
+- [`docs/QUICK_START.md`](./docs/QUICK_START.md) / [`docs/API_REFERENCE.md`](./docs/API_REFERENCE.md) — (현 데모 코드 기준, 지휘자 모델로 재작성 예정)
+
+## 1차 적용 대상
+
+**gwangcheon-shop** — 본 저장소의 지휘자 모델은 이 프로젝트에서 검증된 후 다른 프로젝트로 확장합니다.
+
+## 로컬 실행 (현 데모 코드)
+
+현 시점의 `services/langchain-api/main.py`는 키워드 매칭 기반 데모이며, 지휘자 모델 컴포넌트는 아직 포함되지 않습니다.
+
 ```bash
-git clone https://github.com/rladmsgh34/ai-devops-orchestrator.git
-cd ai-devops-orchestrator
-```
-
-### 2. 환경 설정
-```bash
-cp .env.example .env
-# .env 파일에서 필요한 API 키 설정:
-# - OPENAI_API_KEY (또는 ANTHROPIC_API_KEY)
-# - GITHUB_TOKEN
-# - PROJECT_WEBHOOK_URL
-```
-
-### 3. 원클릭 실행
-```bash
+cp .env.example .env  # 필요한 키만 채움 (없으면 데모 엔드포인트는 동작)
 docker-compose up -d
 ```
 
-### 4. 대시보드 접속
-- **n8n 워크플로우**: http://localhost:5678
-- **LangChain API**: http://localhost:8000
-- **ChromaDB**: http://localhost:8001
+- LangChain API: http://localhost:8000
+- n8n: http://localhost:5678
+- ChromaDB: http://localhost:8001
 
-## 🏗️ 아키텍처
+## 라이선스
 
-```mermaid
-graph TB
-    A[GitHub Repository] -->|Push/PR| B[n8n Webhook]
-    B --> C{Event Type}
-    C -->|Build Failure| D[Error Analyzer Agent]
-    C -->|Deployment| E[Deploy Monitor Agent] 
-    C -->|Security| F[Security Scanner Agent]
-    
-    D --> G[LangChain Processing]
-    E --> G
-    F --> G
-    
-    G --> H[ChromaDB Vector Store]
-    H --> I{Solution Found?}
-    I -->|Yes| J[Auto-Fix PR]
-    I -->|No| K[Human Review Queue]
-    
-    J --> L[Auto-Deploy]
-    K --> M[Notification]
-```
-
-## 🤖 AI 에이전트 구성
-
-### 1. Error Pattern Analyzer
-- **역할**: 빌드/배포 에러 실시간 분석
-- **기술**: LangChain + GPT-4/Claude
-- **특징**: 의존성 체인, 환경 차이, 설정 오류 패턴 학습
-
-### 2. Security Vulnerability Scanner  
-- **역할**: 보안 취약점 자동 탐지
-- **기술**: OWASP Top 10 + 커스텀 룰셋
-- **특징**: XSS, SQL Injection, 의존성 취약점 스캔
-
-### 3. Performance Regression Detector
-- **역할**: 성능 저하 사전 감지
-- **기술**: 메트릭 트렌드 분석
-- **특징**: 응답 시간, 메모리 사용량, DB 쿼리 최적화
-
-### 4. Infrastructure Monitor
-- **역할**: 인프라 상태 24/7 모니터링  
-- **기술**: Docker, Kubernetes, GCP/AWS 연동
-- **특징**: 리소스 사용량, 헬스체크, 자동 스케일링
-
-### 5. Code Quality Enforcer
-- **역할**: 코드 품질 표준 유지
-- **기술**: ESLint, SonarQube, 커스텀 룰
-- **특징**: 복잡도 분석, 테스트 커버리지, 문서화 검증
-
-### 6. Deployment Orchestrator
-- **역할**: 배포 파이프라인 자동 관리
-- **기술**: GitOps + Canary 배포
-- **특징**: 단계별 배포, 자동 롤백, 헬스체크 연동
-
-## 🌟 지원 프레임워크
-
-| 프레임워크 | 언어 | 지원 상태 | 특수 기능 |
-|-----------|------|-----------|----------|
-| **Next.js** | TypeScript/JavaScript | ✅ 완전 지원 | App Router, Prisma 호환 |
-| **Django** | Python | ✅ 완전 지원 | ORM 최적화, Celery 연동 |
-| **React** | TypeScript/JavaScript | ✅ 완전 지원 | Vite, Webpack 호환 |
-| **Vue.js** | TypeScript/JavaScript | ✅ 완전 지원 | Nuxt.js 포함 |
-| **Spring Boot** | Java/Kotlin | ✅ 완전 지원 | Gradle, Maven 지원 |
-| **FastAPI** | Python | 🔄 개발 중 | Pydantic, SQLAlchemy |
-| **Ruby on Rails** | Ruby | 📋 계획됨 | ActiveRecord, Sidekiq |
-
-## 📊 성과 지표
-
-### 실증된 개선 효과
-- **디버깅 시간**: 평균 90분 → **3.7분** (2343% 향상)
-- **배포 실패율**: 23% → **2.1%** (91% 감소)  
-- **MTTR**: 4.2시간 → **11분** (2190% 향상)
-- **개발 생산성**: +340% (반복 작업 자동화)
-
-### 비용 절감
-- **GitHub Actions 비용**: 월 $500 → $50 (90% 절감)
-- **인프라 모니터링 비용**: 월 $800 → $120 (85% 절감)
-- **On-call 비용**: 주 40시간 → 5시간 (87.5% 절감)
-
-## 🔧 커스터마이징
-
-### 새로운 프레임워크 추가
-```python
-# analyzers/custom_framework_analyzer.py
-class CustomFrameworkAnalyzer(BaseAnalyzer):
-    framework = "custom-framework"
-    
-    def analyze_error(self, error_log: str, project_config: dict):
-        # 커스텀 에러 패턴 분석 로직
-        return self.generate_solution(error_log)
-        
-    def get_fix_suggestions(self, analysis_result: dict):
-        # 자동 수정 제안 로직
-        return suggestions
-```
-
-### 커스텀 워크플로우 추가
-```javascript
-// n8n-workflows/custom-trigger.json
-{
-  "name": "Custom Project Monitor",
-  "nodes": [
-    {
-      "name": "Webhook Trigger",
-      "type": "n8n-nodes-base.webhook"
-    },
-    {
-      "name": "AI Analysis",
-      "type": "n8n-nodes-base.httpRequest",
-      "parameters": {
-        "url": "http://langchain-api:8000/analyze"
-      }
-    }
-  ]
-}
-```
-
-## 🤝 기여하기
-
-우리는 오픈소스 커뮤니티의 기여를 환영합니다!
-
-### 🚀 기여 방법
-1. **Fork** 이 저장소
-2. **Feature 브랜치 생성**: `git checkout -b feature/amazing-feature`
-3. **변경사항 커밋**: `git commit -m 'feat: add amazing feature'`
-4. **브랜치에 Push**: `git push origin feature/amazing-feature`
-5. **Pull Request 생성**
-
-### 📋 기여 아이디어
-- [ ] **새로운 프레임워크 지원** (Laravel, Angular, etc.)
-- [ ] **클라우드 플랫폼 확장** (AWS, Azure, Vercel)
-- [ ] **알림 채널 추가** (Slack, Discord, Teams)
-- [ ] **메트릭 대시보드** (Grafana, Prometheus 연동)
-- [ ] **다국어 지원** (중국어, 일본어, 스페인어)
-
-## 📄 라이선스
-
-이 프로젝트는 [MIT License](LICENSE)하에 배포됩니다.
-
-## 🌟 Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=rladmsgh34/ai-devops-orchestrator&type=Date)](https://star-history.com/#rladmsgh34/ai-devops-orchestrator&Date)
-
-## 💬 커뮤니티
-
-- **GitHub Discussions**: [토론 참여](https://github.com/rladmsgh34/ai-devops-orchestrator/discussions)
-- **Discord**: [커뮤니티 채팅](https://discord.gg/ai-devops)
-- **Twitter**: [@AIDevOpsOrg](https://twitter.com/AIDevOpsOrg)
-
-## 🙏 감사 인사
-
-- **LangChain** - AI 에이전트 프레임워크
-- **n8n** - 워크플로우 자동화 플랫폼  
-- **ChromaDB** - 벡터 데이터베이스
-- **Docker** - 컨테이너화 플랫폼
-- **모든 기여자들** - 오픈소스 커뮤니티
-
----
-
-**"Automate the boring stuff, focus on what matters."** 🚀
+[MIT](LICENSE)


### PR DESCRIPTION
## 요약

기존 README의 과장된 청구를 제거하고, 지휘자 모델 + 케이스 주도 원칙에 맞춰 본문을 재작성합니다. case #000 후속 작업.

## 제거된 내용

- 📊 **성과 지표** — "디버깅 시간 2343% 향상", "MTTR 2190% 향상", "월 \$500 → \$50" 등 검증되지 않은 수치
- 🤖 **AI 에이전트 6개 구성** — 일부는 컴포넌트 매트릭스에서 이미 제거됨 (Security Scanner, Code Quality Enforcer 등 Antigravity와 충돌)
- 🔥 **검증된 사례** — `cases/`에 근거 없음 (Prisma v7 의존성 체인, Docker Alpine 등은 별도 케이스로 기록 시점에 재추가 가능)
- 🌟 **지원 프레임워크 표** — "Next.js / Django / React / Vue / Spring Boot ✅ 완전 지원"은 미구현 광고
- 💬 **커뮤니티 섹션** — 존재하지 않는 Discord / Twitter 링크
- 🤝 **기여 아이디어 목록** — 케이스 주도 원칙(가설 기반 기능 금지)과 충돌

## 추가된 내용

- **현재 상태 표** — 5개 레이어가 모두 미구현임을 명시
- **무엇을 만들고 / 만들지 않는가** — CLAUDE.md DO/DON'T 매트릭스 발췌
- **문서 맵** — CLAUDE.md / ARCHITECTURE.md / PIPELINE_STATES.md / cases/ 진입점

## 라인 변화

256줄 → 53줄 추가 / 203줄 삭제 (실질 본문 약 1/4 수준으로 압축)

## Closes

case #000의 README 정직성 후속 작업을 마무리합니다.