### PR TITLE
chore: add .gitignore (worktrees/, __pycache__, .env)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# 별도 git repo 클론 (gwangcheon-shop 등 다른 프로젝트 작업용)
+worktrees/
+
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# 환경변수 (시크릿 노출 방지 — 전역 CLAUDE.md 룰)
+.env
+.env.local


### PR DESCRIPTION
## 요약

본 레포 .gitignore 부재로 인한 추적 누락 위험 정리.

## 변경

- `worktrees/` — 별도 git repo 클론 (gwangcheon-shop 등). 본 레포 추적 대상 아님
- `__pycache__/`, `*.pyc`, `.pytest_cache/` — Python 빌드/캐시 산출물
- `.env`, `.env.local` — 시크릿 (전역 CLAUDE.md 룰: ".env 파일 생성/수정/커밋 절대 금지")

## 트리거

2026-05-05 메인 워킹트리 감사 중 발견:
- `worktrees/ai-dev-loop-analyzer`, `worktrees/gwangcheon-shop`, `worktrees/langchain-devops-analyzer` — 별도 repo 클론 3개가 untracked로 노출
- `scripts/__pycache__/` — Python 캐시 untracked

이전엔 `services/langchain-api/main.py`만 .py 파일이라 캐시 미발생, worktrees/도 직전 세션에서 비어있었음. 제미나이 작업으로 새로 노출됨.

## 체크리스트

- [x] 시크릿 패턴 포함 (.env)
- [x] 멀티 에이전트 worktree 규약과 정합 (전역 CLAUDE.md)
- [x] 코드 변경 0줄, 단순 cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)